### PR TITLE
Small fix for console errors

### DIFF
--- a/lua/autorun/acf_missile/guidance/guidance_wire.lua
+++ b/lua/autorun/acf_missile/guidance/guidance_wire.lua
@@ -139,6 +139,9 @@ end
 
 
 function this:GetGuidance(missile)
+    if not self.InputSource:IsValid() then
+        return {}
+    end
     
     local dist = missile:GetPos():Distance(self.InputSource:GetPos())
     


### PR DESCRIPTION
I was seeing ugly console errors where self.InputSource was a invalid entity, this should fix it.
I'm not sure what was causing it because I was just seeing the console from the panel, but at least it worked as a quick fix.
