### PR TITLE
Changed type(val) == "Entity" to IsEntity(val)

### DIFF
--- a/lua/autorun/acf_missile/guidance/guidance_radar.lua
+++ b/lua/autorun/acf_missile/guidance/guidance_radar.lua
@@ -230,7 +230,7 @@ function this:GetWireTarget(missile)
         
         local val = outTbl.Value
         
-        if type(val) == "Entity" and IsValid(val) then 
+        if IsEntity(val) and IsValid(val) then 
             return val
         end
         


### PR DESCRIPTION
I remember I once told you we had the same problem with wire targeting, IsEntity filters more general stuff like NPCs, players and any other things. This is probably the bug that has been pissing everyone around with radar targeting.
