### PR TITLE
Fully parentable missiles

### DIFF
--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -536,7 +536,7 @@ function ENT:Think()
 		if self.FirstThink == true then
 			self.FirstThink = false
 			self.LastThink = CurTime() - self.ThinkDelay
-			self.LastVel = self.Launcher.Physical:GetVelocity() * self.ThinkDelay
+			self.LastVel = self.Launcher.acfphysparent:GetVelocity() * self.ThinkDelay
 		end
 		self:CalcFlight()
 

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -536,7 +536,7 @@ function ENT:Think()
 		if self.FirstThink == true then
 			self.FirstThink = false
 			self.LastThink = CurTime() - self.ThinkDelay
-			self.LastVel = self.Launcher:GetVelocity() * self.ThinkDelay
+			self.LastVel = self.Launcher.Physical:GetVelocity() * self.ThinkDelay
 		end
 		self:CalcFlight()
 

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -101,6 +101,7 @@ function ENT:Initialize()
 
     self.AmmoLink = {}
     
+    self.Physical = self
 end
 
 
@@ -908,8 +909,23 @@ function ENT:CheckLegal()
 	if not self:IsSolid() then return false end
 	
 	-- make sure weight is not below stock
-	if self:GetPhysicsObject():GetMass() < (self.LegalWeight or self.Mass) then return false end
 	
+	if self:GetPhysicsObject():GetMass() < (self.LegalWeight or self.Mass) then return false end
+	-- if it's not parented we're fine
+	if not IsValid( self:GetParent() ) then return true end
+	local egh = self:GetParent()
+	if IsValid(egh) then
+		local egh2 = egh:GetParent()
+		if IsValid(egh2) then
+			if !IsValid(egh2:GetParent()) then
+				self.Physical = egh2
+				return true
+			end
+		else
+			self.Physical = egh
+			return true
+		end
+	end
 	
 	return false
 	
@@ -920,7 +936,7 @@ end
 function ENT:FireMissile()
     
 	--if self.Ready and self:CheckLegal() and (self.PostReloadWait < CurTime()) then
-	if self.Ready and self:GetPhysicsObject():GetMass() >= (self.LegalWeight or self.Mass) and (self.PostReloadWait < CurTime()) then
+	if self.Ready and self:GetPhysicsObject():GetMass() >= (self.LegalWeight or self.Mass) and (!self:GetParent():IsValid() or self:CheckLegal())and (self.PostReloadWait < CurTime()) then
         
         local nextMsl = self:PeekMissile()
     

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -909,20 +909,12 @@ function ENT:CheckLegal()
 	if not self:IsSolid() then return false end
 	
 	-- make sure weight is not below stock
-	
 	if self:GetPhysicsObject():GetMass() < (self.LegalWeight or self.Mass) then return false end
-	-- if it's not parented we're fine
-	if not IsValid( self:GetParent() ) then return true end
-	local egh = self:GetParent()
-	if IsValid(egh) then
-		local egh2 = egh:GetParent()
-		if IsValid(egh2) then
-			if !IsValid(egh2:GetParent()) then
-				self.Physical = egh2
-				return true
-			end
-		else
-			self.Physical = egh
+	
+	-- if it's parented then we get the physical entity
+	if IsValid( self:GetParent() ) then
+		self.Physical = ACF_GetPhysicalParent(self)
+		if IsValid(self.Physical:GetPhysicsObject()) then
 			return true
 		end
 	end

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -909,25 +909,14 @@ function ENT:CheckLegal()
 	if not self:IsSolid() then return false end
 	
 	-- make sure weight is not below stock
-	
 	if self:GetPhysicsObject():GetMass() < (self.LegalWeight or self.Mass) then return false end
-	-- if it's not parented we're fine
-	if not IsValid( self:GetParent() ) then return true end
-	local egh = self:GetParent()
-	if IsValid(egh) then
-		local egh2 = egh:GetParent()
-		if IsValid(egh2) then
-			if !IsValid(egh2:GetParent()) then
-				self.Physical = egh2
-				return true
-			end
-		else
-			self.Physical = egh
-			return true
-		end
+	
+	-- if it's parented then we get the physical entity
+	if IsValid( self:GetParent() ) then
+		self.Physical = ACF_GetPhysicalParent(self)
 	end
 	
-	return false
+	return true
 	
 end
 
@@ -935,8 +924,7 @@ end
 
 function ENT:FireMissile()
     
-	--if self.Ready and self:CheckLegal() and (self.PostReloadWait < CurTime()) then
-	if self.Ready and self:GetPhysicsObject():GetMass() >= (self.LegalWeight or self.Mass) and (!self:GetParent():IsValid() or self:CheckLegal())and (self.PostReloadWait < CurTime()) then
+	if self.Ready and self:CheckLegal() and (self.PostReloadWait < CurTime()) then
         
         local nextMsl = self:PeekMissile()
     

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -910,15 +910,6 @@ function ENT:CheckLegal()
 	-- make sure weight is not below stock
 	if self:GetPhysicsObject():GetMass() < (self.LegalWeight or self.Mass) then return false end
 	
-	-- if it's not parented we're fine
-	if not IsValid( self:GetParent() ) then return true end
-	
-	local rootparent = ACF_GetPhysicalParent(self)
-
-	--make sure it's welded to root parent
-	for k, v in pairs( constraint.FindConstraints( self, "Weld" ) ) do
-		if v.Ent1 == rootparent or v.Ent2 == rootparent then return true end
-	end
 	
 	return false
 	
@@ -929,7 +920,7 @@ end
 function ENT:FireMissile()
     
 	--if self.Ready and self:CheckLegal() and (self.PostReloadWait < CurTime()) then
-	if self.Ready and self:GetPhysicsObject():GetMass() >= (self.LegalWeight or self.Mass) and (!self:GetParent():IsValid() or self:CheckLegal())and (self.PostReloadWait < CurTime()) then
+	if self.Ready and self:GetPhysicsObject():GetMass() >= (self.LegalWeight or self.Mass) and (self.PostReloadWait < CurTime()) then
         
         local nextMsl = self:PeekMissile()
     

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -99,9 +99,8 @@ function ENT:Initialize()
     
     self.Missiles = {}   
 
-    self.AmmoLink = {}
-    
-    self.Physical = self
+	self.AmmoLink = {}
+	
 end
 
 
@@ -911,12 +910,10 @@ function ENT:CheckLegal()
 	-- make sure weight is not below stock
 	if self:GetPhysicsObject():GetMass() < (self.LegalWeight or self.Mass) then return false end
 	
-	-- if it's parented then we get the physical entity
-	if IsValid( self:GetParent() ) then
-		self.Physical = ACF_GetPhysicalParent(self)
-	end
+	-- update the acfphysparent
+	ACF_GetPhysicalParent(self)
 	
-	return true
+	return self.acfphysparent:IsSolid()
 	
 end
 


### PR DESCRIPTION
Super simple, Let racks work without needing an extra constraint, ACF will still check the weight of the rack and makes sure the rack is solid before its able to fire. Requiring a constraint will add an unnecessary constraint and also make aircraft become less stable. Not to mention, it can be easily bypassed by just constraining the rack before firing. Which renders that feature basically useless. In general, I consider it'd be a great improvement in terms of optimization when using the addon. Reducing the amount of constraints on your contraptions is always appreciated, especially after they stopped being the only way of getting the entities that compose said contraption. EDIT: Code has been changed so that missiles/bombs on racks can inherit velocity while parented. (thank you poly!)