### PR TITLE
Include beam_netvars.lua to fix issue with Wiremod update

### DIFF
--- a/lua/autorun/acf_missiles_include.lua
+++ b/lua/autorun/acf_missiles_include.lua
@@ -15,6 +15,9 @@ AddCSLuaFile("autorun/client/cl_acfm_effectsoverride.lua")
 AddCSLuaFile("autorun/printbyname.lua")
 AddCSLuaFile("acf/client/cl_acfmenu_missileui.lua")
 
+AddCSLuaFile("wire/beam_netvars.lua")
+include("wire/beam_netvars.lua")
+
 if SERVER then
 
   include("gitrc.lua")


### PR DESCRIPTION
This fix will stop ACF missiles from breaking entirely for servers using the Github version of Wiremod (and, likely soon, the workshop version) due to removing support for beam_netvars.lua in [this update](https://github.com/wiremod/wire/commit/3bfdc5c9bdb5fa9bebe39c8a92cc85355483dd8c).

Fixes [#128](https://github.com/Bubbus/ACF-Missiles/issues/128)

In the future, it may be a better alternative to remove the dependency on beam_netvars.lua but for now, this will fix it.