### PR TITLE
Radar missile rebalance

### DIFF
--- a/lua/acf/shared/missiles/missile_aam.lua
+++ b/lua/acf/shared/missiles/missile_aam.lua
@@ -100,7 +100,7 @@ ACF_defineGun("AIM-9 AAM", { --id
 	},
 
     ent         = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
-    guidance    = {"Dumb", "Radar"},
+    guidance    = {"Dumb", "Infrared"},
     fuses       = {"Contact", "Radio"},
 
 	racks       = {["1xRK"] = true,  ["2xRK"] = true, ["3xRK"] = true, ["1xRK_small"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'

--- a/lua/acf/shared/missiles/missile_asm.lua
+++ b/lua/acf/shared/missiles/missile_asm.lua
@@ -320,7 +320,7 @@ ACF_defineGun("AGM-45 ASM", { --id
 	},
 
     ent         = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
-    guidance    = {"Dumb", "Radar", "Laser"},
+    guidance    = {"Dumb", "Infrared", "Laser"},
     fuses       = {"Contact", "Timed"}, 
 
     racks       = {["1xRK"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true, ["6xUARRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
@@ -361,7 +361,7 @@ ACF_defineGun("AGM-122 ASM", { --id
 	},
 
     ent         = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
-    guidance    = {"Dumb", "Radar"},
+    guidance    = {"Dumb", "Infrared"},
     fuses       = {"Contact", "Optical"},
 
 	racks       = {["1xRK"] = true,  ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true, ["1xRK_small"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'

--- a/lua/acf/shared/missiles/missile_sam.lua
+++ b/lua/acf/shared/missiles/missile_sam.lua
@@ -47,7 +47,7 @@ ACF_defineGun("FIM-92 SAM", { --id
 	},
 
     ent         = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
-    guidance    = {"Dumb", "Radar","Antimissile"},
+    guidance    = {"Dumb", "Infrared","Antimissile"},
     fuses       = {"Contact", "Radio"},
 
 	racks       = {["1x FIM-92"] = true,  ["2x FIM-92"] = true,  ["4x FIM-92"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
@@ -89,7 +89,7 @@ ACF_defineGun("Strela-1 SAM", { --id
 	},
 
     ent         = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
-    guidance    = {"Dumb", "Radar","Antimissile"},
+    guidance    = {"Dumb", "Infrared","Antimissile"},
     fuses       = {"Contact", "Radio"},
 
 	racks       = {["1x Strela-1"] = true,  ["2x Strela-1"] = true,  ["4x Strela-1"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'

--- a/lua/autorun/acf_missile/countermeasure/cm_flare.lua
+++ b/lua/autorun/acf_missile/countermeasure/cm_flare.lua
@@ -14,6 +14,7 @@ ACF.Countermeasure[ClassName] = this
 this.AppliesTo = 
 {
 	Radar = true,
+	Infrared = true,
 	Laser = true
 }
 

--- a/lua/autorun/acf_missile/guidance/folder.lua
+++ b/lua/autorun/acf_missile/guidance/folder.lua
@@ -12,3 +12,7 @@ include("autorun/acf_missile/guidance/guidance_radar.lua")
 
 AddCSLuaFile("autorun/acf_missile/guidance/guidance_antimissile.lua")
 include("autorun/acf_missile/guidance/guidance_antimissile.lua")
+
+
+AddCSLuaFile("autorun/acf_missile/guidance/guidance_infrared.lua")
+include("autorun/acf_missile/guidance/guidance_infrared.lua")

--- a/lua/autorun/acf_missile/guidance/guidance_infrared.lua
+++ b/lua/autorun/acf_missile/guidance/guidance_infrared.lua
@@ -1,0 +1,402 @@
+
+local ClassName = "Infrared"
+
+
+ACF = ACF or {}
+ACF.Guidance = ACF.Guidance or {}
+
+local this = ACF.Guidance[ClassName] or inherit.NewSubOf(ACF.Guidance.Wire)
+ACF.Guidance[ClassName] = this
+
+---
+
+
+this.Name = ClassName
+
+--Currently acquired target.
+this.Target = nil
+
+-- Cone to acquire targets within.
+this.SeekCone = 20
+
+-- Cone to retain targets within.
+this.ViewCone = 25
+
+-- Targets this close to the front are good enough.
+this.SeekTolerance = math.cos( math.rad( 2 ) )
+
+-- This instance must wait this long between target seeks.
+this.SeekDelay = 100000 -- The re-seek cycle is expensive, let's disable it until we figure out some optimization.
+
+-- Delay between re-seeks if an entity is provided via wiremod.
+this.WireSeekDelay = 0.1
+
+-- Minimum distance for a target to be considered
+this.MinimumDistance = 393.7	--10m
+
+-- Entity class whitelist
+-- thanks to Sestze for the listing.
+this.DefaultFilter = 
+{
+    prop_physics                = true,
+    gmod_wheel                  = true,
+    gmod_hoverball              = true,
+    gmod_wire_expression2       = true,
+    gmod_wire_thruster          = true,
+    gmod_thruster               = true,
+    gmod_wire_light             = true,
+    gmod_light                  = true,
+    gmod_emitter                = true,
+    gmod_button                 = true,
+    phys_magnet                 = true,
+    prop_vehicle_jeep           = true,
+    prop_vehicle_airboat        = true,
+    prop_vehicle_prisoner_pod   = true,
+    acf_engine                  = true,
+    acf_ammo                    = true,
+    acf_gun                     = true,
+    acf_gearbox                 = true,
+    gmod_wire_hologram		= false	--let's see if this works.  rockets shouldn't home on holos
+}
+
+
+this.desc = "This guidance package detects a target-position infront of itself, and guides the munition towards it."
+
+
+
+function this:Init()
+	self.LastSeek = CurTime() - self.SeekDelay - 0.000001
+    --self.Filter = self.DefaultFilter
+	self.Filter = table.Copy(self.DefaultFilter)
+	self.LastTargetPos = Vector()
+end
+
+
+
+
+function this:Configure(missile)
+    
+    self:super().Configure(self, missile)
+    
+    self.ViewCone = ACF_GetGunValue(missile.BulletData, "viewcone") or this.ViewCone
+	self.ViewConeCos = math.cos(math.rad(self.ViewCone))
+    self.SeekCone = ACF_GetGunValue(missile.BulletData, "seekcone") or this.SeekCone
+    
+end
+
+
+
+-- Use this to make sure you don't alter the shared default filter unintentionally
+function this:GetSeekFilter(class)
+    if self.Filter == self.DefaultFilter then
+        self.Filter = table.Copy(self.DefaultFilter)
+    end
+    
+    return self.Filter
+end
+
+
+
+
+function this:GetNamedWireInputs(missile)
+
+    local launcher = missile.Launcher
+    local outputs = launcher.Outputs
+
+    local names = {}
+    
+    if outputs.Target and outputs.Target.Type == "ENTITY" then
+        names[#names+1] = "Target"
+    end
+    
+    return names
+
+end
+
+
+
+
+function this:GetFallbackWireInputs()
+
+    -- Can't scan for entity outputs: a lot of ents have self-outputs.
+    return {}
+
+end
+
+
+
+
+--TODO: still a bit messy, refactor this so we can check if a flare exits the viewcone too.
+function this:GetGuidance(missile)
+
+	self:PreGuidance(missile)
+	
+	local override = self:ApplyOverride(missile)
+	if override then return override end
+
+	self:CheckTarget(missile)
+	
+	if not IsValid(self.Target) then 
+		return {} 
+	end
+
+	local missilePos = missile:GetPos()
+	local missileForward = missile:GetForward()
+	local targetPhysObj = self.Target:GetPhysicsObject()
+	local targetPos = self.Target:GetPos()
+	
+	-- this was causing radar to break in certain conditions, usually on parented props.
+	--if IsValid(targetPhysObj) then
+		--targetPos = util.LocalToWorld( self.Target, targetPhysObj:GetMassCenter(), nil )
+	--end
+
+	local mfo       = missile:GetForward()
+	local mdir      = (targetPos - missilePos):GetNormalized()
+	local dot       = mfo:Dot(mdir)
+	if dot < self.ViewConeCos then
+		self.Target = nil
+		return {}
+	else
+        self.TargetPos = targetPos
+		return {TargetPos = targetPos, ViewCone = self.ViewCone}
+	end
+	
+end
+
+
+
+
+function this:ApplyOverride(missile)
+	
+	if self.Override then
+	
+		local ret = self.Override:GetGuidanceOverride(missile, self)
+		
+		if ret then		
+			ret.ViewCone = self.ViewCone
+			ret.ViewConeRad = math.rad(self.ViewCone)
+			return ret
+		end
+		
+	end
+
+end
+
+
+
+
+function this:CheckTarget(missile)
+
+	if not (self.Target or self.Override) then	
+		local target = self:AcquireLock(missile)
+
+		if IsValid(target) then 
+			self.Target = target
+		end
+	end
+	
+end
+
+
+
+
+function this:GetWireTarget(missile)
+	
+    local launcher = missile.Launcher
+    local outputs = launcher.Outputs
+    
+    if not IsValid(self.InputSource) then 
+		return nil
+	end
+    
+    local outputs = self.InputSource.Outputs
+    
+    if not outputs then
+        return nil
+	end
+    
+    
+    for k, name in pairs(self.InputNames) do
+        
+        local outTbl = outputs[name]
+        
+        if not (outTbl and outTbl.Value) then continue end
+        
+        local val = outTbl.Value
+        
+        if IsValid(val) and IsEntity(val) then 
+            return val
+        end
+        
+    end
+    
+end
+
+
+
+--ents.findincone not working? weird.
+function JankCone (init, forward, range, cone)
+	local allents = ents.GetAll()
+	local tblout = {}
+	
+	for k, v in pairs (allents) do
+		if not IsValid(v) then continue end
+		local dist = (v:GetPos() - init):Length()
+		local ang = math.deg(math.acos(math.Clamp(((v:GetPos() - init):GetNormalized()):Dot(forward), -1, 1)))
+		if (dist > range) then continue end
+		if (ang > cone) then continue end
+		
+		table.insert(tblout, v)
+	end
+	return tblout
+end
+
+
+
+
+function this:GetWhitelistedEntsInCone(missile)
+
+    local missilePos = missile:GetPos()
+	local missileForward = missile:GetForward()
+	local minDot = math.cos(math.rad(self.SeekCone))
+	
+	--local found = ents.FindInCone(missilePos, missileForward, 50000, self.SeekCone)
+	local found = JankCone(missilePos, missileForward, 50000, self.SeekCone)
+	
+	local foundAnim = {}
+	local foundEnt
+	local minDistSqr = ( self.MinimumDistance * self.MinimumDistance )
+	
+    local filter = self.Filter
+	for i, foundEnt in pairs(found) do
+	
+		--if not (IsValid(foundEnt) and self.Filter[foundEnt:GetClass()]) then continue end
+		if (not IsValid(foundEnt)) or (not self.Filter[foundEnt:GetClass()]) then	continue end
+		local foundLocalPos = foundEnt:GetPos() - missilePos
+		
+		local foundDistSqr = foundLocalPos:LengthSqr()
+		if foundDistSqr < minDistSqr then continue end
+		
+		local foundDot = foundLocalPos:GetNormalized():Dot(missileForward)
+		if foundDot < minDot then continue end
+		
+		table.insert(foundAnim, foundEnt)
+		
+	end
+    
+    return foundAnim
+    
+end
+
+
+
+
+function this:HasLOSVisibility(ent, missile)
+
+	local traceArgs = 
+	{
+		start = missile:GetPos(),
+		endpos = ent:GetPos(),
+		mask = MASK_SOLID_BRUSHONLY,
+		filter = {missile, ent}
+	}
+	
+	local res = util.TraceLine(traceArgs)
+	
+	--debugoverlay.Line( missile:GetPos(), ent:GetPos(), 15, Color(res.Hit and 255 or 0, res.Hit and 0 or 255, 0), true )
+	
+	return not res.Hit
+
+end
+
+
+
+
+-- Return the first entity found within the seek-tolerance, or the entity within the seek-cone closest to the seek-tolerance.
+function this:AcquireLock(missile)
+
+	local curTime = CurTime()
+    
+    if self.LastSeek + self.WireSeekDelay <= curTime then 
+    
+        local wireEnt = self:GetWireTarget(missile)
+        
+        if wireEnt then
+            --print("wiremod provided", wireEnt)
+            return wireEnt
+        end
+        
+    end
+    
+	if self.LastSeek + self.SeekDelay > curTime then 
+        --print("tried seeking within timeout period")
+        return nil 
+    end
+	self.LastSeek = curTime
+
+	-- Part 1: get all whitelisted entities in seek-cone.
+	local found = self:GetWhitelistedEntsInCone(missile)
+    	
+	-- Part 2: get a good seek target
+	local foundCt = table.Count(found)
+	if foundCt < 2 then 
+        --print("shortcircuited and found", found[1])
+        return found[1] 
+    end
+	
+    local missilePos = missile:GetPos()
+	local missileForward = missile:GetForward()
+    
+	local mostCentralEnt 
+	local lastKey
+	
+	while not mostCentralEnt do
+	
+		local ent
+		lastKey, ent = next(found, lastKey)
+		
+		if not ent then break end
+		
+		if self:HasLOSVisibility(ent, missile) then
+			mostCentralEnt = ent
+		end
+		
+	end
+	
+	if not mostCentralEnt then return nil end
+	
+	local mostCentralPos = mostCentralEnt:GetPos()
+	local highestDot = (mostCentralEnt:GetPos() - missilePos):GetNormalized():Dot(missileForward)
+	local currentEnt
+	local currentDot
+	
+	for k, ent in next, found, lastKey do
+		
+		currentEnt = ent
+		currentDot = (currentEnt:GetPos() - missilePos):GetNormalized():Dot(missileForward)
+		
+		if currentDot > highestDot and self:HasLOSVisibility(currentEnt, missile) then
+			mostCentralEnt = currentEnt
+			highestDot = currentDot
+			
+			if currentDot >= self.SeekTolerance then 
+                --print("found", mostCentralEnt, "in tolerance")
+                return currentEnt 
+            end
+		end
+	end
+    
+    --print("iterated and found", mostCentralEnt)
+    
+	return mostCentralEnt
+end
+
+
+
+function this:GetDisplayConfig()
+	return 
+	{
+		["Seeking"] = math.Round(self.SeekCone * 2, 1) .. " deg",
+		["Tracking"] = math.Round(self.ViewCone * 2, 1) .. " deg"
+	}
+end

--- a/lua/autorun/acf_missile/guidance/guidance_radar.lua
+++ b/lua/autorun/acf_missile/guidance/guidance_radar.lua
@@ -153,8 +153,8 @@ function this:GetGuidance(missile)
 	local mfo       = missile:GetForward()
 	local mdir      = (targetPos - missilePos):GetNormalized()
 	local dot       = mfo:Dot(mdir)
-	
-	if dot < self.ViewConeCos then
+	local tr2  = util.QuickTrace( targetPos, ((targetPos-missilePos):GetNormalized() *1000), function( tgt ) if ( tgt == game.GetWorld() ) then return true end end) 
+	if dot < self.ViewConeCos  or ((tr2.Entity) == game.GetWorld() and !tr2.HitSky) then
 		self.Target = nil
 		return {}
 	else


### PR DESCRIPTION
Added a background check to radar missiles which will force the missile to lose lock if there is ground behind the target within 1000 hammer units.

Added infrared guidance mode which works like old radar, attributed to proper missiles.

Reworked AIM-54 into a proper long range intercept missile and reworked AIM-120 to rely on fins instead of constant thrust.